### PR TITLE
Expand ir

### DIFF
--- a/point-derive/Cargo.toml
+++ b/point-derive/Cargo.toml
@@ -11,6 +11,7 @@ edition = '2018'
 [dependencies]
 syn = "0.11.11"
 quote = "0.3.15"
+lazy_static = "~1.3"
 
 [lib]
 proc-macro = true

--- a/point-derive/src/lib.rs
+++ b/point-derive/src/lib.rs
@@ -15,10 +15,27 @@
 *
 * SPDX-License-Identifier: Apache-2.0
 */
+use lazy_static::lazy_static;
 extern crate proc_macro;
 #[macro_use]
 extern crate quote;
 extern crate syn;
+
+lazy_static! {
+    static ref BOOL: Ident = Ident::new("bool");
+    static ref BWC: Ident = Ident::new("BWC");
+    static ref F64: Ident = Ident::new("f64");
+    static ref I32: Ident = Ident::new("i32");
+    static ref I64: Ident = Ident::new("i64");
+    static ref OPTIONAL: Ident = Ident::new("Option");
+    static ref STRING: Ident = Ident::new("String");
+    static ref U8: Ident = Ident::new("u8");
+    static ref U16: Ident = Ident::new("u16");
+    static ref U64: Ident = Ident::new("u64");
+    static ref UUID: Ident = Ident::new("Uuid");
+    static ref VALUE: Ident = Ident::new("Value");
+    static ref VEC: Ident = Ident::new("Vec");
+}
 
 use proc_macro::TokenStream;
 use syn::{Ident, PathParameters, Ty};
@@ -114,24 +131,11 @@ fn impl_struct_point_fields(
             }
             _ => None,
         };
-        let bwc = Ident::new("BWC");
-        let s = Ident::new("String");
-        let i_32 = Ident::new("i32");
-        let i_64 = Ident::new("i64");
-        let f_64 = Ident::new("f64");
-        let u_8 = Ident::new("u8");
-        let u_16 = Ident::new("u16");
-        let u_64 = Ident::new("u64");
-        let uuid = Ident::new("Uuid");
-        let _bool = Ident::new("bool");
-        let _value = Ident::new("Value");
-        let vec = Ident::new("Vec");
-        let optional = Ident::new("Option");
 
-        // In the case of optional types like Option<String> we need to
+        // In the case of OPTIONAL types like Option<String> we need to
         // find the second parameter or we won't know what to do below
         let angle_type: Option<Ident> = if let Some(i_type) = ident_type.clone() {
-            if i_type == optional {
+            if i_type == *OPTIONAL {
                 find_optional_type(field.clone())
             } else {
                 None
@@ -141,7 +145,7 @@ fn impl_struct_point_fields(
         };
 
         let vec_angle_type: Option<Ident> = if let Some(i_type) = ident_type.clone() {
-            if i_type == vec {
+            if i_type == *VEC {
                 find_optional_type(field.clone())
             } else {
                 None
@@ -152,64 +156,64 @@ fn impl_struct_point_fields(
 
         match ident_type {
             Some(i_type) => {
-                if i_type == bwc {
+                if i_type == *BWC {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Long(self.#ident.average()));
                     });
-                } else if i_type == s {
+                } else if i_type == *STRING {
                     result.push(quote! {
                         if !self.#ident.is_empty(){
                             p.add_tag(stringify!(#ident), TsValue::String(self.#ident.clone()));
                         }
                     });
-                } else if i_type == i_32 {
+                } else if i_type == *I32 {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Integer(self.#ident));
                     });
-                } else if i_type == i_64 {
+                } else if i_type == *I64 {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::SignedLong(self.#ident));
                     });
-                } else if i_type == uuid {
+                } else if i_type == *UUID {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::String(self.#ident.to_string()));
                     });
-                } else if i_type == u_8 {
+                } else if i_type == *U8 {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Byte(self.#ident));
                     });
-                } else if i_type == u_16 {
+                } else if i_type == *U16 {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Short(self.#ident));
                     });
-                } else if i_type == u_64 {
+                } else if i_type == *U64 {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Long(self.#ident));
                     });
-                } else if i_type == f_64 {
+                } else if i_type == *F64 {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Float(self.#ident));
                     });
-                } else if i_type == _bool {
+                } else if i_type == *BOOL {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Boolean(self.#ident));
                     });
-                } else if i_type == vec {
+                } else if i_type == *VEC {
                     match &vec_angle_type {
                         Some(ref vec_type) => {
-                            if *vec_type == s {
+                            if *vec_type == *STRING {
                                 result.push(quote! {
                                     p.add_tag(stringify!(#ident), TsValue::Vector(
                                         self.#ident.iter().map(|i| TsValue::String(i.clone())).collect::<Vec<TsValue>>(),
                                     ));
                                 });
-                            } else if *vec_type == u_64 {
+                            } else if *vec_type == *U64 {
                                 result.push(quote! {
                                     p.add_tag(stringify!(#ident), TsValue::Vector(
                                         self.#ident.iter().map(|i| TsValue::Long(*i)).collect::<Vec<TsValue>>(),
                                     ));
                                 });
-                            } else if *vec_type == uuid {
+                            } else if *vec_type == *UUID {
                                 result.push(quote! {
                                     p.add_tag(stringify!(#ident), TsValue::Vector(
                                         self.#ident.iter().map(|i| TsValue::String(i.to_string())).collect::<Vec<TsValue>>(),
@@ -227,11 +231,11 @@ fn impl_struct_point_fields(
                             );
                         }
                     }
-                } else if i_type == optional {
-                    //println!("optional type: {:?} {:?} {:?}", ident, i_type, angle_type,);
+                } else if i_type == *OPTIONAL {
+                    //println!("OPTIONAL type: {:?} {:?} {:?}", ident, i_type, angle_type,);
                     match angle_type {
                         Some(option_type) => {
-                            if option_type == s {
+                            if option_type == *STRING {
                                 result.push(quote! {
                                     if let Some(ref s) = self.#ident{
                                         if !s.is_empty(){
@@ -240,50 +244,50 @@ fn impl_struct_point_fields(
                                         }
                                     }
                                 });
-                            } else if option_type == _bool {
+                            } else if option_type == *BOOL {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
                                         p.add_field(stringify!(#ident),
                                             TsValue::Boolean(self.#ident.unwrap()));
                                     }
                                 });
-                            } else if option_type == bwc {
+                            } else if option_type == *BWC {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
-                                        let bwc_val = self.#ident.clone().unwrap();
+                                        let BWC_val = self.#ident.clone().unwrap();
                                         p.add_field(stringify!(#ident),
-                                            TsValue::Long(bwc_val.average()));
+                                            TsValue::Long(BWC_val.average()));
                                     }
                                 });
-                            } else if option_type == i_32 {
+                            } else if option_type == *I32 {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
                                         p.add_field(stringify!(#ident),
                                             TsValue::Integer(self.#ident.unwrap()));
                                     }
                                 });
-                            } else if option_type == i_64 {
+                            } else if option_type == *I64 {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
                                         p.add_field(stringify!(#ident),
                                             TsValue::SignedLong(self.#ident.unwrap()));
                                     }
                                 });
-                            } else if option_type == uuid {
+                            } else if option_type == *UUID {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
                                         p.add_field(stringify!(#ident),
                                             TsValue::String(self.#ident.unwrap().to_string()));
                                     }
                                 });
-                            } else if option_type == u_64 {
+                            } else if option_type == *U64 {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
                                         p.add_field(stringify!(#ident),
                                             TsValue::Long(self.#ident.unwrap()));
                                     }
                                 });
-                            } else if option_type == f_64 {
+                            } else if option_type == *F64 {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
                                         p.add_field(stringify!(#ident),
@@ -291,7 +295,7 @@ fn impl_struct_point_fields(
                                     }
                                 });
                             } else {
-                                //println!("optional else: {:?}", option_type);
+                                //println!("OPTIONAL else: {:?}", option_type);
                             }
                         }
                         None => {

--- a/point-derive/src/lib.rs
+++ b/point-derive/src/lib.rs
@@ -132,7 +132,7 @@ fn impl_struct_point_fields(
             _ => None,
         };
 
-        // In the case of OPTIONAL types like Option<String> we need to
+        // In the case of optional types like Option<String> we need to
         // find the second parameter or we won't know what to do below
         let angle_type: Option<Ident> = if let Some(i_type) = ident_type.clone() {
             if i_type == *OPTIONAL {
@@ -203,20 +203,20 @@ fn impl_struct_point_fields(
                         Some(ref vec_type) => {
                             if *vec_type == *STRING {
                                 result.push(quote! {
-                                    p.add_tag(stringify!(#ident), TsValue::Vector(
-                                        self.#ident.iter().map(|i| TsValue::String(i.clone())).collect::<Vec<TsValue>>(),
+                                    p.add_tag(stringify!(#ident), TsValue::StringVec(
+                                        self.#ident.clone()
                                     ));
                                 });
                             } else if *vec_type == *U64 {
                                 result.push(quote! {
-                                    p.add_tag(stringify!(#ident), TsValue::Vector(
-                                        self.#ident.iter().map(|i| TsValue::Long(*i)).collect::<Vec<TsValue>>(),
+                                    p.add_tag(stringify!(#ident), TsValue::LongVec(
+                                        self.#ident.clone()
                                     ));
                                 });
                             } else if *vec_type == *UUID {
                                 result.push(quote! {
-                                    p.add_tag(stringify!(#ident), TsValue::Vector(
-                                        self.#ident.iter().map(|i| TsValue::String(i.to_string())).collect::<Vec<TsValue>>(),
+                                    p.add_tag(stringify!(#ident), TsValue::StringVec(
+                                        self.#ident.iter().map(|i| i.to_string()).collect::<Vec<String>>(),
                                     ));
                                 });
                             } else {

--- a/point-derive/src/lib.rs
+++ b/point-derive/src/lib.rs
@@ -328,8 +328,8 @@ fn impl_struct_point_fields(
     } else {
         quote! {
             impl IntoPoint for #name {
-                fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-                    let mut p = TsPoint::new(name.unwrap_or("unknown"), true);
+                fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
+                    let mut p = TsPoint::new(name.unwrap_or("unknown"), is_time_series);
                     #(#result)*
                     vec![p]
                 }
@@ -357,8 +357,8 @@ fn impl_enum_point_fields(name: &syn::Ident, variants: &[syn::Variant]) -> quote
     }
     quote! {
         impl IntoPoint for #name {
-            fn into_point(&self, name: Option<&str>) -> TsPoint {
-                let mut p = TsPoint::new(point_name.unwrap_or("unknown"), true);
+            fn into_point(&self, name: Option<&str>, is_time_series: bool) -> TsPoint {
+                let mut p = TsPoint::new(point_name.unwrap_or("unknown"), is_time_series);
                 match self {
                     #(#result)*
                 }

--- a/point-derive/src/lib.rs
+++ b/point-derive/src/lib.rs
@@ -216,7 +216,7 @@ fn impl_struct_point_fields(
                                     ));
                                 });
                             } else {
-                                println!("vec found {} with inner: {:?}", i_type, vec_angle_type);
+                                //println!("vec found {} with inner: {:?}", i_type, vec_angle_type);
                             }
                         }
                         None => {

--- a/src/brocade.rs
+++ b/src/brocade.rs
@@ -558,7 +558,7 @@ pub fn get_fc_fabrics(
     let mut points = result
         .fc_fabrics
         .iter()
-        .flat_map(|fabric| fabric.into_point(Some("brocade_fc_fabric")))
+        .flat_map(|fabric| fabric.into_point(Some("brocade_fc_fabric"), true))
         .collect::<Vec<TsPoint>>();
     for point in &mut points {
         point.timestamp = Some(t)
@@ -640,7 +640,7 @@ pub fn get_fc_ports(
     let mut points = result
         .fc_ports
         .iter()
-        .flat_map(|port| port.into_point(Some("brocade_fc_port")))
+        .flat_map(|port| port.into_point(Some("brocade_fc_port"), true))
         .collect::<Vec<TsPoint>>();
     for point in &mut points {
         point.timestamp = Some(t)
@@ -685,7 +685,7 @@ pub fn get_fc_switches(
     let mut points = result
         .fc_switches
         .iter()
-        .flat_map(|switch| switch.into_point(Some("brocade_fc_switch")))
+        .flat_map(|switch| switch.into_point(Some("brocade_fc_switch"), true))
         .collect::<Vec<TsPoint>>();
     for point in &mut points {
         point.timestamp = Some(t)

--- a/src/hitachi.rs
+++ b/src/hitachi.rs
@@ -438,7 +438,7 @@ pub fn csv_to_points(
     for result in iter {
         let record = result?;
         let values = into_values(&record, &fields, &headers);
-        let mut p = TsPoint::new(point_name);
+        let mut p = TsPoint::new(point_name, true);
         p.timestamp = t;
         for (name, value) in values {
             match value {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,6 +1,7 @@
 //! Inspiration for these structs come from compiler design patterns.  TsPoint
 //! is an intermediate representation that is used to abstract
-//! time series data points. 
+//! time series data points.
+use std::collections::HashMap;
 /**
 * Copyright 2019 Comcast Cable Communications Management, LLC
 *
@@ -18,8 +19,6 @@
 *
 * SPDX-License-Identifier: Apache-2.0
 */
-use std::collections::HashMap;
-
 use chrono::{DateTime, Utc};
 use influx_db_client::keys::{Point, Value};
 
@@ -42,7 +41,11 @@ impl TsPoint {
             measurement: String::from(measurement),
             tags: HashMap::new(),
             fields: HashMap::new(),
-            timestamp: if is_time_series { Some(Utc::now())} else {None},
+            timestamp: if is_time_series {
+                Some(Utc::now())
+            } else {
+                None
+            },
             index_field: None,
         }
     }
@@ -58,8 +61,10 @@ impl TsPoint {
     }
 
     /// Set the field to be used for indexing if supported
-    pub fn set_index_field<T: ToString>(&mut self, index_field: T)  {
-        self.index_field = Some(index_field.to_string());
+    pub fn set_index_field(&mut self, index_field: &str) {
+        if !self.fields.contains_key(index_field) {
+            self.index_field = Some(index_field.to_string());
+        }
     }
 
     /// Set the timestamp for this time point

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -58,8 +58,8 @@ impl TsPoint {
     }
 
     /// Set the field to be used for indexing if supported
-    pub fn set_index_field<T: ToString>(&mut self, f: T)  {
-        self.index_field = Some(f.to_string());
+    pub fn set_index_field<T: ToString>(&mut self, index_field: T)  {
+        self.index_field = Some(index_field.to_string());
     }
 
     /// Set the timestamp for this time point

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,3 +1,7 @@
+//! Inspiration for these structs came from compiler design.  TsPoint
+//! is an intermediate representation that is used to abstract 
+//! time series data points.  Point is similar but represents 
+//! data points that are not time series.
 /**
 * Copyright 2019 Comcast Cable Communications Management, LLC
 *
@@ -21,8 +25,7 @@ use std::collections::HashMap;
 use chrono::{DateTime, Utc};
 use influx_db_client::keys::{Point, Value};
 
-/// An intermediate representation of the data that
-/// isn't as lossy as influx_db_client's Point enum
+/// An intermediate representation of time series data points
 #[derive(Clone, Debug)]
 pub struct TsPoint {
     pub measurement: String,
@@ -67,6 +70,7 @@ pub enum TsValue {
     Short(u16),
     SignedLong(i64),
     String(String),
+    Vector(Vec<TsValue>),
 }
 
 pub fn point_to_ts(points: Vec<Point>) -> Vec<TsPoint> {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,7 +1,7 @@
 //! Inspiration for these structs come from compiler design patterns.  TsPoint
 //! is an intermediate representation that is used to abstract
 //! time series data points.
-use std::collections::HashMap;
+use crate::error::{MetricsResult, StorageError};
 /**
 * Copyright 2019 Comcast Cable Communications Management, LLC
 *
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 */
 use chrono::{DateTime, Utc};
 use influx_db_client::keys::{Point, Value};
+use std::collections::HashMap;
 
 /// An intermediate representation of time series data points
 #[derive(Clone, Debug)]
@@ -61,9 +62,15 @@ impl TsPoint {
     }
 
     /// Set the field to be used for indexing if supported
-    pub fn set_index_field(&mut self, index_field: &str) {
-        if !self.fields.contains_key(index_field) {
+    pub fn set_index_field(&mut self, index_field: &str) -> MetricsResult<()> {
+        if self.fields.contains_key(index_field) || self.tags.contains_key(index_field) {
             self.index_field = Some(index_field.to_string());
+            Ok(())
+        } else {
+            Err(StorageError::new(format!(
+                "{} index field is not contained within tags or fields",
+                index_field
+            )))
         }
     }
 

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -72,14 +72,22 @@ impl TsPoint {
 #[derive(Clone, Debug)]
 pub enum TsValue {
     Boolean(bool),
+    BooleanVec(Vec<bool>),
     Byte(u8),
+    ByteVec(Vec<u8>),
     Integer(i32),
+    IntegerVec(Vec<i32>),
     Float(f64),
+    FloatVec(Vec<f64>),
     Long(u64),
+    LongVec(Vec<u64>),
     Short(u16),
+    ShortVec(Vec<u16>),
+    SignedShortVec(Vec<i16>),
     SignedLong(i64),
+    SignedLongVec(Vec<i64>),
     String(String),
-    Vector(Vec<TsValue>),
+    StringVec(Vec<String>),
 }
 
 /// Convert InfluxDB Points to TsPoints

--- a/src/isilon.rs
+++ b/src/isilon.rs
@@ -213,10 +213,10 @@ impl IntoPoint for NodeDrivesNodeDrive {
         if let Some(pending_actions) = &self.pending_actions {
             point.add_field(
                 "pending_actions",
-                TsValue::Vector(pending_actions
+                TsValue::StringVec(pending_actions
                     .iter()
-                    .map(|action| TsValue::String(action.clone()))
-                    .collect::<Vec<TsValue>>(),
+                    .map(|action| action.clone())
+                    .collect::<Vec<String>>(),
                 )
             );
         }

--- a/src/isilon.rs
+++ b/src/isilon.rs
@@ -210,14 +210,16 @@ impl IntoPoint for NodeDrivesNodeDrive {
         if let Some(ref model) = self.model {
             point.add_field("model", TsValue::String(model.clone()));
         }
-        /*
-        if let Some(pending_actions) = drive.pending_actions {
+        if let Some(pending_actions) = &self.pending_actions {
             point.add_field(
                 "pending_actions",
-                TsValue::String(",".join(pending_actions)),
+                TsValue::Vector(pending_actions
+                    .iter()
+                    .map(|action| TsValue::String(action.clone()))
+                    .collect::<Vec<TsValue>>(),
+                )
             );
         }
-        */
         if let Some(physical_block_length) = self.physical_block_length {
             point.add_field(
                 "physical_block_length",

--- a/src/isilon.rs
+++ b/src/isilon.rs
@@ -50,7 +50,7 @@ pub struct IsilonConfig {
 
 impl IntoPoint for ClusterStatfs {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut point = TsPoint::new(name.unwrap_or("isilon_usage"));
+        let mut point = TsPoint::new(name.unwrap_or("isilon_usage"), true);
         point.add_field("f_bavail", TsValue::Long(self.f_bavail));
         point.add_field("f_bfree", TsValue::Long(self.f_bfree));
         point.add_field("f_blocks", TsValue::Long(self.f_blocks));
@@ -76,7 +76,7 @@ impl IntoPoint for NodeStatus {
         let mut points: Vec<TsPoint> = Vec::new();
         if let Some(ref nodes) = self.nodes {
             for node in nodes {
-                let mut point = TsPoint::new(name.unwrap_or("isilon_node_status"));
+                let mut point = TsPoint::new(name.unwrap_or("isilon_node_status"), true);
                 if let Some(ref capacity_items) = node.capacity {
                     for item in capacity_items {
                         if let Some(ref device_type) = item._type {
@@ -161,7 +161,7 @@ impl IntoPoint for NodeStatus {
 
 impl IntoPoint for NodeDrivesNodeDrive {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut point = TsPoint::new(name.unwrap_or("isilon_drives"));
+        let mut point = TsPoint::new(name.unwrap_or("isilon_drives"), true);
 
         if let Some(ref bay_group) = self.bay_group {
             point.add_field("bay_group", TsValue::String(bay_group.clone()));
@@ -261,7 +261,7 @@ impl IntoPoint for NodeDrivesNodeDrive {
 
 impl IntoPoint for SummaryProtocolStats {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut point = TsPoint::new(name.unwrap_or("isilon_perf"));
+        let mut point = TsPoint::new(name.unwrap_or("isilon_perf"), true);
 
         if let Some(ref stats) = self.protocol_stats {
             if let Some(ref cpu) = stats.cpu {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ pub mod vnx;
 pub mod xtremio;
 
 pub trait IntoPoint {
-    fn into_point(&self, name: Option<&str>) -> Vec<ir::TsPoint>;
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<ir::TsPoint>;
 }
 
 pub trait ChildPoint {

--- a/src/netapp.rs
+++ b/src/netapp.rs
@@ -285,10 +285,10 @@ pub struct NetappVolumes {
 }
 
 impl IntoPoint for NetappVolumes {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         for vol in &self.vols {
-            points.extend(vol.into_point(name));
+            points.extend(vol.into_point(name, is_time_series));
         }
         points
     }
@@ -813,7 +813,7 @@ pub fn get_volume_performance(
     let mut points: Vec<TsPoint> = res
         .perf
         .iter()
-        .flat_map(|vol| vol.into_point(Some("netapp_volume_stat")))
+        .flat_map(|vol| vol.into_point(Some("netapp_volume_stat"), true))
         .collect();
     // Set all the timestamps to be identical
     for p in &mut points {
@@ -840,7 +840,7 @@ pub fn get_volume_usage(
     let mut points: Vec<TsPoint> = res
         .vols
         .iter()
-        .flat_map(|vol| vol.into_point(Some("netapp_volume")))
+        .flat_map(|vol| vol.into_point(Some("netapp_volume"), true))
         .collect();
     // Set all the timestamps to be identical
     for p in &mut points {

--- a/src/openstack.rs
+++ b/src/openstack.rs
@@ -157,11 +157,11 @@ pub struct Volumes {
 }
 
 impl IntoPoint for Volumes {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
 
         for v in &self.volumes {
-            points.extend(v.into_point(name));
+            points.extend(v.into_point(name, is_time_series));
         }
 
         points
@@ -282,7 +282,7 @@ pub fn list_volumes(
         &format!("v3/{}/volumes/detail?all_tenants=True", project_id),
     )?;
 
-    Ok(volumes.into_point(Some("openstack_volume")))
+    Ok(volumes.into_point(Some("openstack_volume"), true))
 }
 
 #[test]

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -1120,11 +1120,11 @@ impl IntoPoint for SdsObject {
         let mut p = TsPoint::new(name.unwrap_or("scaleio_sds"), true);
         p.add_field(
             "ip_list",
-            TsValue::Vector(
+            TsValue::StringVec(
                 self.ip_list
                     .iter()
-                    .map(|i| TsValue::String(format!("{}", i.ip)))
-                    .collect::<Vec<TsValue>>(),
+                    .map(|i| format!("{}", i.ip))
+                    .collect::<Vec<String>>(),
             ),
         );
         p.add_field("on_vm_ware", TsValue::Boolean(self.on_vm_ware));

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -23,7 +23,6 @@
 *
 * SPDX-License-Identifier: Apache-2.0
 */
-
 use crate::deserialize_string_or_int;
 use crate::error::{MetricsResult, StorageError};
 use crate::ir::{TsPoint, TsValue};
@@ -1121,12 +1120,11 @@ impl IntoPoint for SdsObject {
         let mut p = TsPoint::new(name.unwrap_or("scaleio_sds"));
         p.add_field(
             "ip_list",
-            TsValue::String(
+            TsValue::Vector(
                 self.ip_list
                     .iter()
-                    .map(|i| format!("{}", i.ip))
-                    .collect::<Vec<String>>()
-                    .join(","),
+                    .map(|i| TsValue::String(format!("{}", i.ip)))
+                    .collect::<Vec<TsValue>>(),
             ),
         );
         p.add_field("on_vm_ware", TsValue::Boolean(self.on_vm_ware));

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -407,7 +407,7 @@ pub struct DeviceStatistics {
 
 impl IntoPoint for DeviceStatistics {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("scaleio_drive_stat"));
+        let mut p = TsPoint::new(name.unwrap_or("scaleio_drive_stat"), true);
         p.add_field(
             "avg_write_size_in_bytes",
             TsValue::Long(self.avg_write_size_in_bytes),
@@ -786,7 +786,7 @@ pub struct SdcMappingInfo {
 
 impl IntoPoint for SdcMappingInfo {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("scaleio_volume_sdc"));
+        let mut p = TsPoint::new(name.unwrap_or("scaleio_volume_sdc"), true);
         p.add_tag("sdc_id", TsValue::String(self.sdc_id.clone()));
         p.add_tag("sdc_ip", TsValue::String(self.sdc_ip.clone()));
         p.add_field("limit_iops", TsValue::Long(self.limit_iops));
@@ -818,7 +818,7 @@ pub struct SdsVolume {
 impl IntoPoint for SdsVolume {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
-        let mut p = TsPoint::new(name.unwrap_or("scaleio_volume"));
+        let mut p = TsPoint::new(name.unwrap_or("scaleio_volume"), true);
         p.add_tag("id", TsValue::String(self.id.clone()));
         if let Some(ref name) = self.name {
             p.add_tag("name", TsValue::String(name.clone()));
@@ -1117,7 +1117,7 @@ pub struct SdsObject {
 
 impl IntoPoint for SdsObject {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("scaleio_sds"));
+        let mut p = TsPoint::new(name.unwrap_or("scaleio_sds"), true);
         p.add_field(
             "ip_list",
             TsValue::Vector(

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -304,7 +304,7 @@ fn test_scaleio_drive_stats() {
     f.read_to_string(&mut buff).unwrap();
 
     let i: DeviceStatistics = serde_json::from_str(&buff).unwrap();
-    let points = i.into_point(Some("scaleio_device"));
+    let points = i.into_point(Some("scaleio_device"), true);
     println!("result: {:#?}", i);
     println!("points: {:?}", points);
 }

--- a/src/telegraf.rs
+++ b/src/telegraf.rs
@@ -79,7 +79,7 @@ fn test_telegraf_parsing() {
 fn parse_telegraf(output: &str, point_name: Option<&str>) -> MetricsResult<TsPoint> {
     // Data model
     // <metric name>{<label name>=<label value>, ...}
-    let mut point = TsPoint::new(point_name.unwrap_or("telegraf"));
+    let mut point = TsPoint::new(point_name.unwrap_or("telegraf"), true);
     for line in output.lines() {
         if line.starts_with('#') {
             continue;

--- a/src/vmax.rs
+++ b/src/vmax.rs
@@ -261,7 +261,7 @@ pub struct Symmetrix {
 
 impl IntoPoint for Symmetrix {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("unknown"));
+        let mut p = TsPoint::new(name.unwrap_or("vmax_symmetrix"), true);
         p.add_tag("symmetrixId", TsValue::String(self.symmetrixId.clone()));
         if let Some(d) = self.device_count {
             p.add_field("device_count", TsValue::SignedLong(d));
@@ -1045,7 +1045,7 @@ pub struct VmaxSystemCapacity {
 
 impl IntoPoint for VmaxSystemCapacity {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("unknown"));
+        let mut p = TsPoint::new(name.unwrap_or("vmax_system_capacity"), true);
         p.add_tag("symmetrix_id", TsValue::String(self.symmetrix_id.clone()));
         p.add_field("device_count", TsValue::Long(self.device_count));
         p.add_field("ucode", TsValue::String(self.ucode.clone()));

--- a/src/vmax.rs
+++ b/src/vmax.rs
@@ -61,7 +61,7 @@ where
     );
     let j: T = crate::get(&client, &url, &config.user, Some(&config.password))?;
 
-    Ok(j.into_point(Some(point_name)))
+    Ok(j.into_point(Some(point_name), true))
 }
 
 /* Changed the GET to POST and added body parameter to pass additional fields to
@@ -92,7 +92,7 @@ where
     let json_res: Result<T, serde_json::Error> = serde_json::from_str(&array_output);
     trace!("json result: {:?}", json_res);
     let json_res = json_res?;
-    Ok(json_res.into_point(Some(point_name)))
+    Ok(json_res.into_point(Some(point_name), true))
 }
 
 /* Changed the GET to POST and added body parameter to pass additional field to w/o IntoPoint
@@ -160,10 +160,10 @@ pub struct Srps {
 }
 
 impl IntoPoint for Srps {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         for s in &self.srp {
-            points.extend(s.into_point(name));
+            points.extend(s.into_point(name, is_time_series));
         }
         points
     }
@@ -200,10 +200,10 @@ pub struct StorageGroups {
 }
 
 impl IntoPoint for StorageGroups {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         for s in &self.storageGroup {
-            points.extend(s.into_point(name));
+            points.extend(s.into_point(name, is_time_series));
         }
         points
     }
@@ -238,10 +238,10 @@ pub struct SloArray {
 }
 
 impl IntoPoint for SloArray {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         for s in &self.symmetrix {
-            points.extend(s.into_point(name));
+            points.extend(s.into_point(name, is_time_series));
         }
         points
     }
@@ -260,8 +260,8 @@ pub struct Symmetrix {
 }
 
 impl IntoPoint for Symmetrix {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("vmax_symmetrix"), true);
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
+        let mut p = TsPoint::new(name.unwrap_or("vmax_symmetrix"), is_time_series);
         p.add_tag("symmetrixId", TsValue::String(self.symmetrixId.clone()));
         if let Some(d) = self.device_count {
             p.add_field("device_count", TsValue::SignedLong(d));
@@ -319,7 +319,7 @@ fn test_get_slo_arrays() {
 
     let i: SloArray = serde_json::from_str(&buff).unwrap();
     println!("result: {:#?}", i);
-    println!("point: {:#?}", i.into_point(Some("slo_arrays")));
+    println!("point: {:#?}", i.into_point(Some("slo_arrays"), true));
 }
 
 pub fn get_slo_arrays(client: &reqwest::Client, config: &VmaxConfig) -> MetricsResult<Vec<String>> {
@@ -352,7 +352,7 @@ fn test_get_slo_array_srps() {
 
     let i: Srps = serde_json::from_str(&buff).unwrap();
     println!("result: {:#?}", i);
-    println!("point: {:#?}", i.into_point(Some("srp")));
+    println!("point: {:#?}", i.into_point(Some("srp"), true));
 }
 
 pub fn get_slo_array_srps(
@@ -395,7 +395,7 @@ fn test_get_slo_array_storagegroups() {
 
     let i: StorageGroups = serde_json::from_str(&buff).unwrap();
     println!("result: {:#?}", i);
-    println!("point: {:#?}", i.into_point(Some("storage_group")));
+    println!("point: {:#?}", i.into_point(Some("storage_group"), true));
 }
 
 pub fn get_slo_array_storagegroups(
@@ -444,10 +444,10 @@ pub struct FedArray {
 }
 
 impl IntoPoint for FedArray {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         for s in &self.fe_director_info {
-            points.extend(s.into_point(name));
+            points.extend(s.into_point(name, is_time_series));
         }
         points
     }
@@ -511,16 +511,16 @@ pub struct FedArrayMetrics {
 }
 
 impl IntoPoint for FedArrayMetrics {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        self.result_list.into_point(name)
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
+        self.result_list.into_point(name, is_time_series)
     }
 }
 
 impl IntoPoint for FedResult {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         for r in &self.result {
-            let res = r.into_point(name);
+            let res = r.into_point(name, is_time_series);
             points.extend(res);
         }
         points
@@ -627,10 +627,10 @@ pub struct PortGroupArray {
 }
 
 impl IntoPoint for PortGroupArray {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         for s in &self.port_group_info {
-            points.extend(s.into_point(name));
+            points.extend(s.into_point(name, is_time_series));
         }
         points
     }
@@ -665,16 +665,16 @@ pub struct PortGroupArrayMetrics {
 }
 
 impl IntoPoint for PortGroupArrayMetrics {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        self.result_list.into_point(name)
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
+        self.result_list.into_point(name, is_time_series)
     }
 }
 
 impl IntoPoint for PgResult {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         for r in &self.result {
-            let res = r.into_point(name);
+            let res = r.into_point(name, is_time_series);
             points.extend(res);
         }
         points
@@ -762,10 +762,10 @@ pub struct StorageGroupArray {
 }
 
 impl IntoPoint for StorageGroupArray {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         for s in &self.storage_group_info {
-            points.extend(s.into_point(name));
+            points.extend(s.into_point(name, is_time_series));
         }
         points
     }
@@ -827,16 +827,16 @@ pub struct StorageGroupArrayMetrics {
 }
 
 impl IntoPoint for StorageGroupArrayMetrics {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        self.result_list.into_point(name)
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
+        self.result_list.into_point(name, is_time_series)
     }
 }
 
 impl IntoPoint for SgResult {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         for r in &self.result {
-            let res = r.into_point(name);
+            let res = r.into_point(name, is_time_series);
             points.extend(res);
         }
         points
@@ -1044,8 +1044,8 @@ pub struct VmaxSystemCapacity {
 }
 
 impl IntoPoint for VmaxSystemCapacity {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("vmax_system_capacity"), true);
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
+        let mut p = TsPoint::new(name.unwrap_or("vmax_system_capacity"), is_time_series);
         p.add_tag("symmetrix_id", TsValue::String(self.symmetrix_id.clone()));
         p.add_field("device_count", TsValue::Long(self.device_count));
         p.add_field("ucode", TsValue::String(self.ucode.clone()));

--- a/src/vnx.rs
+++ b/src/vnx.rs
@@ -200,11 +200,11 @@ pub struct FileSystemCapacity {
 }
 
 impl IntoPoint for FileSystemCapacities {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let capacity_points: Vec<TsPoint> = self
             .capacity
             .iter()
-            .flat_map(|f| f.into_point(name))
+            .flat_map(|f| f.into_point(name, is_time_series))
             .collect();
 
         capacity_points
@@ -428,10 +428,10 @@ pub struct Mounts {
 }
 
 impl IntoPoint for Mounts {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         for m in &self.mounts {
-            points.extend(m.into_point(Some(name.unwrap_or("vnx_mounts"))));
+            points.extend(m.into_point(Some(name.unwrap_or("vnx_mounts")), is_time_series));
         }
 
         points
@@ -547,14 +547,14 @@ pub struct NetworkAllSample {
 }
 
 impl IntoPoint for NetworkAllSample {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut p = TsPoint::new(name.unwrap_or("networking_usage"), true);
         p.add_tag("mover", TsValue::String(self.mover.clone()));
         // Turn these counters into point arrays, get the first one and merge
         // the fields with this point
-        p.fields.extend(self.ip.into_point(None)[0].fields.clone());
-        p.fields.extend(self.tcp.into_point(None)[0].fields.clone());
-        p.fields.extend(self.udp.into_point(None)[0].fields.clone());
+        p.fields.extend(self.ip.into_point(None, is_time_series)[0].fields.clone());
+        p.fields.extend(self.tcp.into_point(None, is_time_series)[0].fields.clone());
+        p.fields.extend(self.udp.into_point(None, is_time_series)[0].fields.clone());
         for device in &self.devices {
             p.add_tag("device", TsValue::String(device.device.clone()));
             p.add_field(
@@ -792,27 +792,27 @@ pub struct CifsAllSample {
 }
 
 impl IntoPoint for CifsAllSample {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut p = TsPoint::new(name.unwrap_or("cifs_usage"), true);
         p.add_tag("mover", TsValue::String(self.mover.clone()));
         // Turn these counters into point arrays, get the first one and merge
         // the fields with this point
         p.fields
-            .extend(self.smb_calls.into_point(None)[0].fields.clone());
+            .extend(self.smb_calls.into_point(None, is_time_series)[0].fields.clone());
         p.fields
-            .extend(self.smb_time.into_point(None)[0].fields.clone());
+            .extend(self.smb_time.into_point(None, is_time_series)[0].fields.clone());
         p.fields
-            .extend(self.trans2_calls.into_point(None)[0].fields.clone());
+            .extend(self.trans2_calls.into_point(None, is_time_series)[0].fields.clone());
         p.fields
-            .extend(self.trans2_time.into_point(None)[0].fields.clone());
+            .extend(self.trans2_time.into_point(None, is_time_series)[0].fields.clone());
         p.fields
-            .extend(self.nt_calls.into_point(None)[0].fields.clone());
+            .extend(self.nt_calls.into_point(None, is_time_series)[0].fields.clone());
         p.fields
-            .extend(self.nt_time.into_point(None)[0].fields.clone());
+            .extend(self.nt_time.into_point(None, is_time_series)[0].fields.clone());
         p.fields
-            .extend(self.state.into_point(None)[0].fields.clone());
+            .extend(self.state.into_point(None, is_time_series)[0].fields.clone());
         p.fields
-            .extend(self.totals.into_point(None)[0].fields.clone());
+            .extend(self.totals.into_point(None, is_time_series)[0].fields.clone());
 
         vec![p]
     }
@@ -1038,26 +1038,26 @@ pub struct NfsAllSample {
 }
 
 impl IntoPoint for NfsAllSample {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut p = TsPoint::new(name.unwrap_or("nfs_usage"), true);
         p.add_tag("mover", TsValue::String(self.mover.clone()));
         // Turn these counters into point arrays, get the first one and merge
         // the fields with this point
         p.fields
-            .extend(self.proc_v2_calls.into_point(None)[0].fields.clone());
+            .extend(self.proc_v2_calls.into_point(None, is_time_series)[0].fields.clone());
         p.fields
-            .extend(self.proc_v2_failures.into_point(None)[0].fields.clone());
+            .extend(self.proc_v2_failures.into_point(None, is_time_series)[0].fields.clone());
         p.fields
-            .extend(self.proc_v2_time.into_point(None)[0].fields.clone());
+            .extend(self.proc_v2_time.into_point(None, is_time_series)[0].fields.clone());
         p.fields
-            .extend(self.proc_v3_calls.into_point(None)[0].fields.clone());
+            .extend(self.proc_v3_calls.into_point(None, is_time_series)[0].fields.clone());
         p.fields
-            .extend(self.proc_v3_failures.into_point(None)[0].fields.clone());
+            .extend(self.proc_v3_failures.into_point(None, is_time_series)[0].fields.clone());
         p.fields
-            .extend(self.proc_v3_time.into_point(None)[0].fields.clone());
+            .extend(self.proc_v3_time.into_point(None, is_time_series)[0].fields.clone());
         p.fields
-            .extend(self.cache.into_point(None)[0].fields.clone());
-        p.fields.extend(self.rpc.into_point(None)[0].fields.clone());
+            .extend(self.cache.into_point(None, is_time_series)[0].fields.clone());
+        p.fields.extend(self.rpc.into_point(None, is_time_series)[0].fields.clone());
 
         vec![p]
     }
@@ -1258,10 +1258,10 @@ impl FromXml for DiskInfo {
 }
 
 impl IntoPoint for DiskInfo {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         for disk in &self.disks {
-            points.extend(disk.into_point(name));
+            points.extend(disk.into_point(name, is_time_series));
         }
 
         points
@@ -1293,8 +1293,8 @@ pub struct ResourceUsageSample {
 }
 
 impl IntoPoint for ResourceUsageSample {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("resource_usage"), true);
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
+        let mut p = TsPoint::new(name.unwrap_or("resource_usage"), is_time_series);
         p.add_tag("mover", TsValue::String(self.mover.clone()));
         p.add_field("cpu", TsValue::Float(self.cpu));
         p.add_field("memory", TsValue::Float(self.mem));
@@ -1418,11 +1418,11 @@ pub struct FilesystemUsage {
 }
 
 impl IntoPoint for FilesystemUsage {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
 
         for f in &self.filesystems {
-            let mut p = TsPoint::new(name.unwrap_or("filesystem_usage"), true);
+            let mut p = TsPoint::new(name.unwrap_or("filesystem_usage"), is_time_series);
             p.add_tag("filesystem_id", TsValue::String(f.filesystem_id.clone()));
             p.add_field("space_total", TsValue::Long(f.space_total));
             p.add_field("space_used", TsValue::Long(f.space_used));
@@ -1560,8 +1560,8 @@ pub struct Volume {
 }
 
 impl IntoPoint for Volume {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("volume"), true);
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
+        let mut p = TsPoint::new(name.unwrap_or("volume"), is_time_series);
         match self.vol_type {
             VolumeType::Disk(ref v) => {
                 p.add_tag(
@@ -1923,7 +1923,7 @@ fn test_storage_pool_query_parser() {
     };
     let res = StoragePools::from_xml(&data).unwrap();
     println!("result: {:#?}", res);
-    let _ = res.into_point(None);
+    let _ = res.into_point(None, is_time_series);
 }
 
 #[derive(Debug)]
@@ -1950,8 +1950,8 @@ pub struct StoragePool {
 }
 
 impl IntoPoint for StoragePool {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("pool"), true);
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
+        let mut p = TsPoint::new(name.unwrap_or("pool"), is_time_series);
         p.add_tag("pool", TsValue::String(self.pool.clone()));
         /* get serial number from description. Assuming this is last token */
         let mut serial_number = self
@@ -1981,10 +1981,10 @@ impl IntoPoint for StoragePool {
 
 // Collecting the new information to include the pool name and pool ID and for VNXs where there are multiple pools
 impl IntoPoint for StoragePools {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         for pool in &self.storage_pools {
-            points.extend(pool.into_point(name));
+            points.extend(pool.into_point(name, is_time_series));
         }
         points
     }
@@ -2374,7 +2374,7 @@ where
         end_query_stats_request(&mut writer)?;
     }
     let res: T = api_request(&client, &config, output, cookie_jar)?;
-    Ok(res.into_point(None))
+    Ok(res.into_point(None, true))
 }
 
 /*
@@ -2456,7 +2456,7 @@ pub fn disk_info_request(
     }
     debug!("{}", String::from_utf8_lossy(&output));
     let res: DiskInfo = api_request(&client, &config, output, cookie_jar)?;
-    Ok(res.into_point(Some("vnx_disk_info")))
+    Ok(res.into_point(Some("vnx_disk_info"), true))
 }
 
 pub fn filesystem_capacity_request(
@@ -2478,7 +2478,7 @@ pub fn filesystem_capacity_request(
         end_query_request(&mut writer)?;
     }
     let res: FileSystemCapacities = api_request(&client, &config, output, cookie_jar)?;
-    Ok(res.into_point(Some("vnx_filesystem_capacity")))
+    Ok(res.into_point(Some("vnx_filesystem_capacity"), true))
 }
 
 pub fn filesystem_usage_request(
@@ -2495,7 +2495,7 @@ pub fn filesystem_usage_request(
         end_query_stats_request(&mut writer)?;
     }
     let res: FilesystemUsage = api_request(&client, &config, output, cookie_jar)?;
-    Ok(res.into_point(None))
+    Ok(res.into_point(None, true))
 }
 
 /// A VNX mount is identified by the Data Mover ID and the mount path
@@ -2519,7 +2519,7 @@ pub fn mount_listing_request(
     }
     // Request the mount info from the VNX
     let res: Mounts = api_request(&client, &config, output, cookie_jar)?;
-    Ok(res.into_point(None))
+    Ok(res.into_point(None, true))
 }
 
 fn begin_query_request<W: Write>(w: &mut EventWriter<W>) -> MetricsResult<()> {

--- a/src/vnx.rs
+++ b/src/vnx.rs
@@ -402,7 +402,7 @@ fn test_filesystem_capacity_parser() {
         s
     };
     let res = FileSystemCapacities::from_xml(&data).unwrap();
-    let points = res.into_point(Some("vnx_filesystem_capacity"));
+    let points = res.into_point(Some("vnx_filesystem_capacity"), true);
     println!("result: {:#?}", points);
 }
 
@@ -418,7 +418,7 @@ fn test_mount_parser() {
         s
     };
     let res = Mounts::from_xml(&data).unwrap();
-    let points = res.into_point(None);
+    let points = res.into_point(None, true);
     println!("result: {:#?}", points);
 }
 
@@ -530,7 +530,7 @@ fn test_network_all_parser() {
         s
     };
     let res = NetworkAllSample::from_xml(&data).unwrap();
-    let points = res.into_point(None);
+    let points = res.into_point(None, true);
     println!("result: {:#?}", points);
 }
 
@@ -1923,7 +1923,7 @@ fn test_storage_pool_query_parser() {
     };
     let res = StoragePools::from_xml(&data).unwrap();
     println!("result: {:#?}", res);
-    let _ = res.into_point(None, is_time_series);
+    let _ = res.into_point(None, true);
 }
 
 #[derive(Debug)]

--- a/src/vnx.rs
+++ b/src/vnx.rs
@@ -548,7 +548,7 @@ pub struct NetworkAllSample {
 
 impl IntoPoint for NetworkAllSample {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("networking_usage"));
+        let mut p = TsPoint::new(name.unwrap_or("networking_usage"), true);
         p.add_tag("mover", TsValue::String(self.mover.clone()));
         // Turn these counters into point arrays, get the first one and merge
         // the fields with this point
@@ -793,7 +793,7 @@ pub struct CifsAllSample {
 
 impl IntoPoint for CifsAllSample {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("cifs_usage"));
+        let mut p = TsPoint::new(name.unwrap_or("cifs_usage"), true);
         p.add_tag("mover", TsValue::String(self.mover.clone()));
         // Turn these counters into point arrays, get the first one and merge
         // the fields with this point
@@ -1039,7 +1039,7 @@ pub struct NfsAllSample {
 
 impl IntoPoint for NfsAllSample {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("nfs_usage"));
+        let mut p = TsPoint::new(name.unwrap_or("nfs_usage"), true);
         p.add_tag("mover", TsValue::String(self.mover.clone()));
         // Turn these counters into point arrays, get the first one and merge
         // the fields with this point
@@ -1294,7 +1294,7 @@ pub struct ResourceUsageSample {
 
 impl IntoPoint for ResourceUsageSample {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("resource_usage"));
+        let mut p = TsPoint::new(name.unwrap_or("resource_usage"), true);
         p.add_tag("mover", TsValue::String(self.mover.clone()));
         p.add_field("cpu", TsValue::Float(self.cpu));
         p.add_field("memory", TsValue::Float(self.mem));
@@ -1422,7 +1422,7 @@ impl IntoPoint for FilesystemUsage {
         let mut points: Vec<TsPoint> = Vec::new();
 
         for f in &self.filesystems {
-            let mut p = TsPoint::new(name.unwrap_or("filesystem_usage"));
+            let mut p = TsPoint::new(name.unwrap_or("filesystem_usage"), true);
             p.add_tag("filesystem_id", TsValue::String(f.filesystem_id.clone()));
             p.add_field("space_total", TsValue::Long(f.space_total));
             p.add_field("space_used", TsValue::Long(f.space_used));
@@ -1561,7 +1561,7 @@ pub struct Volume {
 
 impl IntoPoint for Volume {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("volume"));
+        let mut p = TsPoint::new(name.unwrap_or("volume"), true);
         match self.vol_type {
             VolumeType::Disk(ref v) => {
                 p.add_tag(
@@ -1951,7 +1951,7 @@ pub struct StoragePool {
 
 impl IntoPoint for StoragePool {
     fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
-        let mut p = TsPoint::new(name.unwrap_or("pool"));
+        let mut p = TsPoint::new(name.unwrap_or("pool"), true);
         p.add_tag("pool", TsValue::String(self.pool.clone()));
         /* get serial number from description. Assuming this is last token */
         let mut serial_number = self

--- a/src/xtremio.rs
+++ b/src/xtremio.rs
@@ -80,12 +80,12 @@ pub struct Volumes {
 }
 
 impl IntoPoint for Volumes {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         let n = name.unwrap_or("volume");
 
         for v in &self.volumes {
-            points.extend(v.into_point(Some(n)));
+            points.extend(v.into_point(Some(n), is_time_series));
         }
 
         points
@@ -203,12 +203,12 @@ pub struct Ssds {
 }
 
 impl IntoPoint for Ssds {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         let n = name.unwrap_or("ssd");
 
         for v in &self.ssds {
-            points.extend(v.into_point(Some(n)));
+            points.extend(v.into_point(Some(n), is_time_series));
         }
 
         points
@@ -303,12 +303,12 @@ pub struct Psus {
 }
 
 impl IntoPoint for Psus {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         let n = name.unwrap_or("psu");
 
         for v in &self.storage_controller_psus {
-            points.extend(v.into_point(Some(n)));
+            points.extend(v.into_point(Some(n), is_time_series));
         }
 
         points
@@ -375,12 +375,12 @@ pub struct Clusters {
 }
 
 impl IntoPoint for Clusters {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         let n = name.unwrap_or("cluster");
 
         for v in &self.clusters {
-            points.extend(v.into_point(Some(n)));
+            points.extend(v.into_point(Some(n), is_time_series));
         }
 
         points
@@ -769,12 +769,12 @@ pub struct Xmss {
 }
 
 impl IntoPoint for Xmss {
-    fn into_point(&self, name: Option<&str>) -> Vec<TsPoint> {
+    fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
         let mut points: Vec<TsPoint> = Vec::new();
         let n = name.unwrap_or("xms");
 
         for xms in &self.xmss {
-            points.extend(xms.into_point(Some(n)));
+            points.extend(xms.into_point(Some(n), is_time_series));
         }
 
         points
@@ -886,7 +886,7 @@ where
     );
     let j: T = crate::get(&client, &url, &config.user, Some(&config.password))?;
 
-    Ok(j.into_point(Some(point_name)))
+    Ok(j.into_point(Some(point_name), true))
 }
 
 pub fn get_clusters(

--- a/xml-attributes-derive/src/lib.rs
+++ b/xml-attributes-derive/src/lib.rs
@@ -153,7 +153,7 @@ fn impl_struct_xml_fields(name: &syn::Ident, fields: &syn::Fields) -> quote::Tok
         let ident_name = {
             let i = i.as_ref();
             if i.starts_with("_") {
-                i.trim_left_matches("_")
+                i.trim_start_matches("_")
             } else {
                 i
             }


### PR DESCRIPTION
There's 2 parts to this PR and i'd be happy to break this up if it's confusing.  I expanded the scope of the intermediate representation to take into account data that isn't well suited to time series.  Code that then processes the TsPoint's can make better decisions about what to do.  I also added a TsValue::Vector which can either be used or ignored by processing code.  The thought here is that IR code shouldn't be losing information that the final processing code might need.  The second part is I added some code to point-derive to expand the scope of what it's capable of recognizing.  That code though is horribly repetitive and likely needs to be rewritten more cleanly.  