### PR TITLE
Update point-derive to latest dependencies

### DIFF
--- a/point-derive/Cargo.toml
+++ b/point-derive/Cargo.toml
@@ -9,7 +9,6 @@ homepage = "https://github.com/Comcast/libstorage"
 edition = '2018'
 
 [dependencies]
-lazy_static = "~1.3"
 proc-macro2 = "0.4"
 quote = "~0.6"
 syn = "~0.15"

--- a/point-derive/Cargo.toml
+++ b/point-derive/Cargo.toml
@@ -9,9 +9,10 @@ homepage = "https://github.com/Comcast/libstorage"
 edition = '2018'
 
 [dependencies]
-syn = "0.11.11"
-quote = "0.3.15"
 lazy_static = "~1.3"
+proc-macro2 = "0.4"
+quote = "~0.6"
+syn = "~0.15"
 
 [lib]
 proc-macro = true

--- a/point-derive/src/lib.rs
+++ b/point-derive/src/lib.rs
@@ -15,85 +15,70 @@
 *
 * SPDX-License-Identifier: Apache-2.0
 */
-use lazy_static::lazy_static;
 extern crate proc_macro;
-#[macro_use]
-extern crate quote;
-extern crate syn;
 
-lazy_static! {
-    static ref BOOL: Ident = Ident::new("bool");
-    static ref BWC: Ident = Ident::new("BWC");
-    static ref F64: Ident = Ident::new("f64");
-    static ref I32: Ident = Ident::new("i32");
-    static ref I64: Ident = Ident::new("i64");
-    static ref OPTIONAL: Ident = Ident::new("Option");
-    static ref STRING: Ident = Ident::new("String");
-    static ref U8: Ident = Ident::new("u8");
-    static ref U16: Ident = Ident::new("u16");
-    static ref U64: Ident = Ident::new("u64");
-    static ref UUID: Ident = Ident::new("Uuid");
-    static ref VALUE: Ident = Ident::new("Value");
-    static ref VEC: Ident = Ident::new("Vec");
-}
-
+//use lazy_static::lazy_static;
+use quote::quote;
 use proc_macro::TokenStream;
-use syn::{Ident, PathParameters, Ty};
+use proc_macro2::{Ident, Span};
+use syn::{parse_macro_input, DeriveInput};//, Ident, PathParameters, Ty};
+
 
 #[proc_macro_derive(IntoPoint)]
 pub fn point_derive(input: TokenStream) -> TokenStream {
-    // Construct a string representation of the type definition
-    let s = input.to_string();
-
     // Parse the string representation
-    let ast = syn::parse_derive_input(&s).unwrap();
+    let ast = parse_macro_input!(input as DeriveInput);
 
     // Build the impl
-    let gen = impl_point(&ast, false);
+    let generated = impl_point(&ast, false);
 
     // Return the generated impl
-    gen.parse().unwrap()
+    TokenStream::from(generated)
 }
 
 #[proc_macro_derive(IntoChildPoint)]
 pub fn child_point_derive(input: TokenStream) -> TokenStream {
-    // Construct a string representation of the type definition
-    let s = input.to_string();
-
     // Parse the string representation
-    let ast = syn::parse_derive_input(&s).unwrap();
+    let ast = parse_macro_input!(input as DeriveInput);
 
     // Build the impl
-    let gen = impl_point(&ast, true);
+    let generated = impl_point(&ast, true);
 
     // Return the generated impl
-    gen.parse().unwrap()
+    TokenStream::from(generated)
 }
 
-fn impl_point(ast: &syn::DeriveInput, child: bool) -> quote::Tokens {
+fn impl_point(ast: &DeriveInput, child: bool) -> TokenStream {
     let name = &ast.ident;
-    match ast.body {
-        syn::Body::Struct(ref data) => impl_struct_point_fields(name, data.fields(), child),
-        syn::Body::Enum(ref data) => {
+    match ast.data {
+        syn::Data::Struct(ref data) => impl_struct_point_fields(name, &data.fields, child),
+        syn::Data::Enum(ref data) => {
             println!("into_enum_point_fields called");
-            impl_enum_point_fields(name, data)
+            impl_enum_point_fields(name, &data.variants.iter().collect())
         }
+        _ => unimplemented!(),
     }
 }
 
 fn find_optional_type(field: syn::Field) -> Option<Ident> {
     match field.clone().ty {
-        Ty::Path(_, p) => {
-            if let Some(i) = p.segments.clone().into_iter().next() {
-                match i.parameters {
-                    PathParameters::AngleBracketed(a) => {
-                        for ty in a.types {
+        syn::Type::Path(p) => {
+            if let Some(i) = p.path.segments.clone().into_iter().next() {
+                match i.arguments {
+                    syn::PathArguments::AngleBracketed(a) => {
+                        //println!("{:?}", a);
+                        for ty in a.args {
                             match ty {
-                                Ty::Path(_, p2) => {
-                                    if let Some(i2) = p2.segments.clone().into_iter().next() {
-                                        return Some(i2.ident);
-                                    } else {
-                                        return None;
+                                syn::GenericArgument::Type(p2) => {
+                                    match p2 {
+                                        syn::Type::Path(p2) => {
+                                            if let Some(i2) = p2.path.segments.clone().into_iter().next() {
+                                                return Some(i2.ident);
+                                            } else {
+                                                return None;
+                                            }
+                                        }
+                                        _ => return None
                                     }
                                 }
                                 _ => return None,
@@ -115,15 +100,29 @@ fn find_optional_type(field: syn::Field) -> Option<Ident> {
 
 fn impl_struct_point_fields(
     name: &syn::Ident,
-    fields: &[syn::Field],
+    fields: &syn::Fields,
     child: bool,
-) -> quote::Tokens {
+) -> TokenStream {
+    let _bool: Ident = Ident::new("bool", Span::call_site());
+    let bwc: Ident = Ident::new("BWC", Span::call_site());
+    let f_64: Ident = Ident::new("f64", Span::call_site());
+    let i_32: Ident = Ident::new("i32", Span::call_site());
+    let i_64: Ident = Ident::new("i64", Span::call_site());
+    let optional: Ident = Ident::new("Option", Span::call_site());
+    let s: Ident = Ident::new("String", Span::call_site());
+    let u_8: Ident = Ident::new("u8", Span::call_site());
+    let u_16: Ident = Ident::new("u16", Span::call_site());
+    let u_64: Ident = Ident::new("u64", Span::call_site());
+    let uuid: Ident = Ident::new("Uuid", Span::call_site());
+    let value: Ident = Ident::new("Value", Span::call_site());
+    let _vec: Ident = Ident::new("Vec", Span::call_site());
+
     let mut result = Vec::new();
     for field in fields {
         let ident = &field.ident;
         let ident_type = match field.clone().ty {
-            Ty::Path(_, p) => {
-                if let Some(i) = p.segments.clone().into_iter().next() {
+            syn::Type::Path(p) => {
+                if let Some(i) = p.path.segments.clone().into_iter().next() {
                     Some(i.ident)
                 } else {
                     None
@@ -135,7 +134,7 @@ fn impl_struct_point_fields(
         // In the case of optional types like Option<String> we need to
         // find the second parameter or we won't know what to do below
         let angle_type: Option<Ident> = if let Some(i_type) = ident_type.clone() {
-            if i_type == *OPTIONAL {
+            if i_type == optional {
                 find_optional_type(field.clone())
             } else {
                 None
@@ -145,7 +144,7 @@ fn impl_struct_point_fields(
         };
 
         let vec_angle_type: Option<Ident> = if let Some(i_type) = ident_type.clone() {
-            if i_type == *VEC {
+            if i_type == _vec {
                 find_optional_type(field.clone())
             } else {
                 None
@@ -156,64 +155,64 @@ fn impl_struct_point_fields(
 
         match ident_type {
             Some(i_type) => {
-                if i_type == *BWC {
+                if i_type == bwc {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Long(self.#ident.average()));
                     });
-                } else if i_type == *STRING {
+                } else if i_type == s {
                     result.push(quote! {
                         if !self.#ident.is_empty(){
                             p.add_tag(stringify!(#ident), TsValue::String(self.#ident.clone()));
                         }
                     });
-                } else if i_type == *I32 {
+                } else if i_type == i_32 {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Integer(self.#ident));
                     });
-                } else if i_type == *I64 {
+                } else if i_type == i_64 {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::SignedLong(self.#ident));
                     });
-                } else if i_type == *UUID {
+                } else if i_type == uuid {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::String(self.#ident.to_string()));
                     });
-                } else if i_type == *U8 {
+                } else if i_type == u_8 {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Byte(self.#ident));
                     });
-                } else if i_type == *U16 {
+                } else if i_type == u_16 {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Short(self.#ident));
                     });
-                } else if i_type == *U64 {
+                } else if i_type == u_64 {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Long(self.#ident));
                     });
-                } else if i_type == *F64 {
+                } else if i_type == f_64 {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Float(self.#ident));
                     });
-                } else if i_type == *BOOL {
+                } else if i_type == _bool {
                     result.push(quote! {
                         p.add_field(stringify!(#ident), TsValue::Boolean(self.#ident));
                     });
-                } else if i_type == *VEC {
+                } else if i_type == _vec {
                     match &vec_angle_type {
                         Some(ref vec_type) => {
-                            if *vec_type == *STRING {
+                            if *vec_type == s {
                                 result.push(quote! {
                                     p.add_tag(stringify!(#ident), TsValue::StringVec(
                                         self.#ident.clone()
                                     ));
                                 });
-                            } else if *vec_type == *U64 {
+                            } else if *vec_type == u_64 {
                                 result.push(quote! {
                                     p.add_tag(stringify!(#ident), TsValue::LongVec(
                                         self.#ident.clone()
                                     ));
                                 });
-                            } else if *vec_type == *UUID {
+                            } else if *vec_type == uuid {
                                 result.push(quote! {
                                     p.add_tag(stringify!(#ident), TsValue::StringVec(
                                         self.#ident.iter().map(|i| i.to_string()).collect::<Vec<String>>(),
@@ -231,11 +230,11 @@ fn impl_struct_point_fields(
                             );
                         }
                     }
-                } else if i_type == *OPTIONAL {
-                    //println!("OPTIONAL type: {:?} {:?} {:?}", ident, i_type, angle_type,);
+                } else if i_type == optional {
+                    //println!("optional type: {:?} {:?} {:?}", ident, i_type, angle_type,);
                     match angle_type {
                         Some(option_type) => {
-                            if option_type == *STRING {
+                            if option_type == s {
                                 result.push(quote! {
                                     if let Some(ref s) = self.#ident{
                                         if !s.is_empty(){
@@ -244,50 +243,50 @@ fn impl_struct_point_fields(
                                         }
                                     }
                                 });
-                            } else if option_type == *BOOL {
+                            } else if option_type == _bool {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
                                         p.add_field(stringify!(#ident),
                                             TsValue::Boolean(self.#ident.unwrap()));
                                     }
                                 });
-                            } else if option_type == *BWC {
+                            } else if option_type == bwc {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
-                                        let BWC_val = self.#ident.clone().unwrap();
+                                        let bwc_val = self.#ident.clone().unwrap();
                                         p.add_field(stringify!(#ident),
-                                            TsValue::Long(BWC_val.average()));
+                                            TsValue::Long(bwc_val.average()));
                                     }
                                 });
-                            } else if option_type == *I32 {
+                            } else if option_type == i_32 {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
                                         p.add_field(stringify!(#ident),
                                             TsValue::Integer(self.#ident.unwrap()));
                                     }
                                 });
-                            } else if option_type == *I64 {
+                            } else if option_type == i_64 {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
                                         p.add_field(stringify!(#ident),
                                             TsValue::SignedLong(self.#ident.unwrap()));
                                     }
                                 });
-                            } else if option_type == *UUID {
+                            } else if option_type == uuid {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
                                         p.add_field(stringify!(#ident),
                                             TsValue::String(self.#ident.unwrap().to_string()));
                                     }
                                 });
-                            } else if option_type == *U64 {
+                            } else if option_type == u_64 {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
                                         p.add_field(stringify!(#ident),
                                             TsValue::Long(self.#ident.unwrap()));
                                     }
                                 });
-                            } else if option_type == *F64 {
+                            } else if option_type == f_64 {
                                 result.push(quote! {
                                     if self.#ident.is_some(){
                                         p.add_field(stringify!(#ident),
@@ -295,7 +294,7 @@ fn impl_struct_point_fields(
                                     }
                                 });
                             } else {
-                                //println!("OPTIONAL else: {:?}", option_type);
+                                //println!("optional else: {:?}", option_type);
                             }
                         }
                         None => {
@@ -318,15 +317,15 @@ fn impl_struct_point_fields(
         }
     }
     if child {
-        quote! {
+        TokenStream::from(quote! {
             impl ChildPoint for #name {
                 fn sub_point(&self, p: &mut TsPoint) {
                     #(#result)*
                 }
             }
-        }
+        })
     } else {
-        quote! {
+        TokenStream::from(quote! {
             impl IntoPoint for #name {
                 fn into_point(&self, name: Option<&str>, is_time_series: bool) -> Vec<TsPoint> {
                     let mut p = TsPoint::new(name.unwrap_or("unknown"), is_time_series);
@@ -334,18 +333,18 @@ fn impl_struct_point_fields(
                     vec![p]
                 }
             }
-        }
+        })
     }
 }
 
-fn impl_enum_point_fields(name: &syn::Ident, variants: &[syn::Variant]) -> quote::Tokens {
+fn impl_enum_point_fields(name: &syn::Ident, variants: &Vec<&syn::Variant>) -> TokenStream {
     let mut result = Vec::new();
     for variant in variants {
         let ident = &variant.ident;
         match variant.discriminant {
-            Some(ref val) => {
+            Some((ref _eq, ref expr)) => {
                 result.push(quote! {
-                    &#name::#ident => #val.into_point(&mut buff),
+                    &#name::#ident => #expr.into_point(&mut buff),
                 });
             }
             None => {
@@ -355,7 +354,7 @@ fn impl_enum_point_fields(name: &syn::Ident, variants: &[syn::Variant]) -> quote
             }
         }
     }
-    quote! {
+    TokenStream::from(quote! {
         impl IntoPoint for #name {
             fn into_point(&self, name: Option<&str>, is_time_series: bool) -> TsPoint {
                 let mut p = TsPoint::new(point_name.unwrap_or("unknown"), is_time_series);
@@ -365,5 +364,5 @@ fn impl_enum_point_fields(name: &syn::Ident, variants: &[syn::Variant]) -> quote
                 p
             }
         }
-    }
+    })
 }

--- a/point-derive/src/lib.rs
+++ b/point-derive/src/lib.rs
@@ -17,11 +17,10 @@
 */
 extern crate proc_macro;
 
-//use lazy_static::lazy_static;
 use quote::quote;
 use proc_macro::TokenStream;
 use proc_macro2::{Ident, Span};
-use syn::{parse_macro_input, DeriveInput};//, Ident, PathParameters, Ty};
+use syn::{parse_macro_input, DeriveInput};
 
 
 #[proc_macro_derive(IntoPoint)]


### PR DESCRIPTION
Ugh, so updating to the latest syn/quote invalided my previous idea about making the Ident's into globals with lazy static.  They are no longer thread safe for some reason.  Anyways, I don't think this changes the behavior but it's hard to tell with generated code.