### PR TITLE
Fix solidfire and vmax data types

### DIFF
--- a/src/solidfire.rs
+++ b/src/solidfire.rs
@@ -764,7 +764,8 @@ struct HardwareDrive {
     size: u64,
     slot: u64,
     uncorrectable_errors: u64,
-    uuid: Uuid,
+    #[serde(rename="uuid")]
+    hardware_uuid: Uuid,
     vendor: String,
     version: String,
 }

--- a/src/vmax.rs
+++ b/src/vmax.rs
@@ -213,7 +213,8 @@ impl IntoPoint for StorageGroups {
 #[allow(non_snake_case)]
 #[derive(Debug, Deserialize, IntoPoint)]
 pub struct StorageGroup {
-    pub storageGroupId: String,
+    #[serde(rename="storageGroupId")]
+    pub storage_group_id: String,
     pub slo: Option<String>,
     pub srp: Option<String>,
     pub workload: Option<String>,
@@ -426,7 +427,7 @@ pub fn get_slo_array_storagegroup(
         config,
         &format!("sloprovisioning/symmetrix/{}/storagegroup/{}", id, group),
         "slo_array_storagegroup",
-        false,
+        true,
     )?;
     Ok(points)
 }


### PR DESCRIPTION
I changed slo_array_storagegroup back to time series for the time being until we can put a plan into place to use that correctly.