### PR TITLE
The ldev_id should be converted to hex

### DIFF
--- a/src/hitachi.rs
+++ b/src/hitachi.rs
@@ -129,7 +129,7 @@ impl IntoPoint for StorageLdev {
                 .into_iter()
                 // Tag each port with ldev_id
                 .map(|mut point| {
-                    point.add_field("ldev_id", TsValue::Long(self.ldev_id.clone()));
+                    point.add_tag("ldev_id", TsValue::String(convert_to_base16(self.ldev_id.clone())));
                     point
                 })
                 .collect();


### PR DESCRIPTION
This is a bugfix.  I should've converted the ldev_id to hex like I did for the port to make it consistent.