### PR TITLE
Scaleio powerflex 3.5.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libstorage"
-version = "0.4.9"
+version = "0.4.91"
 authors = ["Chris Holcombe <christopher_holcombe@comcast.com>", "Sravanthi Dandamudi <sravanthi_dandamudi@comcast.com>", "Rob Powers <comcastrp@gmail.com>"]
 description = "Storage helper functions"
 documentation = "https://github.com/Comcast/libstorage"

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -2049,10 +2049,13 @@ impl IntoPoint for SystemStatistics {
                 p.add_field("thin_capacity_in_use_in_kb", TsValue::Long(net_thin_user_data_capacity_in_kb * 2))
             }
         }
-        p.add_field(
-            "snap_capacity_in_use_in_kb",
-            TsValue::Long(self.snap_capacity_in_use_in_kb),
-        );
+        if let Some(snap_capacity_in_use_in_kb) = self.snap_capacity_in_use_in_kb {
+            p.add_field(
+                "snap_capacity_in_use_in_kb",
+                TsValue::Long(snap_capacity_in_use_in_kb),
+            );
+        }
+        
         p.add_field(
             "unreachable_unused_capacity_in_kb",
             TsValue::Long(self.unreachable_unused_capacity_in_kb),
@@ -2061,10 +2064,13 @@ impl IntoPoint for SystemStatistics {
             "unused_capacity_in_kb",
             TsValue::Long(self.unused_capacity_in_kb),
         );
-        p.add_field(
-            "snap_capacity_in_use_occupied_in_kb",
-            TsValue::Long(self.snap_capacity_in_use_occupied_in_kb),
-        );
+        if let Some(snap_capacity_in_use_in_kb) = self.snap_capacity_in_use_in_kb
+        {
+            p.add_field(
+                "snap_capacity_in_use_in_kb",
+                TsValue::Long(snap_capacity_in_use_in_kb),
+            );
+        }
         p.add_field(
             "thin_capacity_allocated_in_kb",
             TsValue::Long(self.thin_capacity_allocated_in_kb),

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -2079,10 +2079,13 @@ impl IntoPoint for SystemStatistics {
             "spare_capacity_in_kb",
             TsValue::Long(self.spare_capacity_in_kb),
         );
-        p.add_field(
-            "fixed_read_error_count",
-            TsValue::Long(self.fixed_read_error_count),
-        );
+        if let Some(fixed_read_error_count) = self.fixed_read_error_count{
+            p.add_field(
+                "fixed_read_error_count",
+                TsValue::Long(fixed_read_error_count),
+            );
+        }
+        
         p.add_field(
             "num_of_unmapped_volumes",
             TsValue::Long(self.num_of_unmapped_volumes),

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -2789,7 +2789,7 @@ impl Scaleio {
     }
 
     pub fn get_pool_stats(&self) -> MetricsResult<ClusterSelectedStatisticsResponse> {
-        let version = self.get_version();
+        let version = self.get_version().parse::<f64>()?;
         if version >= 3.0 {
             let stats_req = SelectedStatisticsRequest {
                 selected_statistics_list: vec![StatsRequest {
@@ -2956,16 +2956,6 @@ impl Scaleio {
             points
         })?;
         Ok(systemstats)
-    }
-
-    /// Get the version number of the SIO API
-    pub fn get_version(&self) -> MetricsResult<f64> {
-        let version = get::<String>(
-            &self.client,
-            &self.config,
-            &format!("version"),
-        )?;
-        Ok(version.parse::<f64>()?);
     }
 
     pub fn get_system(&self, system_id: &str) -> MetricsResult<System> {

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -2789,9 +2789,10 @@ impl Scaleio {
     }
 
     pub fn get_pool_stats(&self) -> MetricsResult<ClusterSelectedStatisticsResponse> {
-        let version = self.get_version().parse::<f64>()?;
+        let version = self.get_version()?.parse::<f64>()?;
+        let stats_req: SelectedStatisticsRequest;
         if version >= 3.0 {
-            let stats_req = SelectedStatisticsRequest {
+            stats_req = SelectedStatisticsRequest {
                 selected_statistics_list: vec![StatsRequest {
                     req_type: StatsRequestType::StoragePool,
                     all_ids: vec![],
@@ -2812,7 +2813,7 @@ impl Scaleio {
                 }],
             };
         } else {
-            let stats_req = SelectedStatisticsRequest {
+            stats_req = SelectedStatisticsRequest {
                 selected_statistics_list: vec![StatsRequest {
                     req_type: StatsRequestType::StoragePool,
                     all_ids: vec![],

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -412,7 +412,7 @@ pub struct DeviceStatistics {
     fgl_spares_in_kb: Option<u64>,            // NEW V3
     fgl_migration_completion_percent: Option<u64>, // NEW V3
     fgl_user_data_capacity_in_kb: Option<u64>, // NEW V3
-    fixed_read_error_count: u64,              //in v3
+    fixed_read_error_count: Option<u64>,              //in v3
     fwd_rebuild_read_bwc: BWC,                // in v3
     fwd_rebuild_write_bwc: BWC,               // in v3
     in_maintenance_vac_in_kb: u64,            // in v3
@@ -1299,7 +1299,7 @@ pub struct SdsStatistics {
     degraded_failed_vac_in_kb: u64,
     degraded_healthy_vac_in_kb: u64,
     failed_vac_in_kb: u64,
-    fixed_read_error_count: u64,
+    fixed_read_error_count: Option<u64>,
     fwd_rebuild_read_bwc: BWC,
     fwd_rebuild_write_bwc: BWC,
     in_maintenance_vac_in_kb: u64,

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -2789,9 +2789,9 @@ impl Scaleio {
     }
 
     pub fn get_pool_stats(&self) -> MetricsResult<ClusterSelectedStatisticsResponse> {
-        let version = self.get_version()?.parse::<f64>()?;
+        let version = self.get_version()?;
         let stats_req: SelectedStatisticsRequest;
-        if version >= 3.0 {
+        if version >= "3.0".to_string() {
             stats_req = SelectedStatisticsRequest {
                 selected_statistics_list: vec![StatsRequest {
                     req_type: StatsRequestType::StoragePool,

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -216,7 +216,7 @@ pub struct OscillatingCounterWindow {
     pub background_scan_compare_count: Option<u64>,
     pub background_scanned_in_mb: Option<u64>,
     #[serde(flatten)]
-    pub thin_capacity_allocated_in_km: ThinCapacityAllocatedInKb,
+    pub thin_capacity_allocated_in_km: Option<ThinCapacityAllocatedInKb>, //This value is optional 
     pub rm_pending_allocated_in_kb: Option<u64>,
     pub semi_protected_vac_in_kb: Option<u64>,
     pub in_maintenance_vac_in_kb: Option<u64>,

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -1724,7 +1724,7 @@ pub struct System {
     pub tls_version: String,                            // in v3
     pub show_guid: bool,                                // in v3
     pub authentication_method: String,                  // in v3
-    pub mdm_to_sds_policy: String,                      // in v3
+    pub mdm_to_sds_policy: Option<String>,                      // in v3
     pub mdm_cluster: MdmCluster,                        // in v3
     pub perf_profile: PerfProfile,                      // in v3
     pub install_id: String,                             // in v3

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -385,7 +385,7 @@ pub struct DeviceStatistics {
     avg_write_latency_in_microsec: u64,       // in v3
     avg_read_size_in_bytes: u64,              // in v3
     #[serde(rename = "BackgroundScanCompareCount")]
-    background_scan_compare_count: u64, // in v3
+    background_scan_compare_count: Option<u64>, // in v3
     #[serde(rename = "BackgroundScannedInMB")]
     background_scanned_in_mb: u64, // in v3
     bck_rebuild_write_bwc: BWC,               // in v3
@@ -1289,7 +1289,7 @@ pub struct SdsStatistics {
     active_moving_out_norm_rebuild_jobs: u64,
     active_moving_rebalance_jobs: u64,
     #[serde(rename = "BackgroundScanCompareCount")]
-    background_scan_compare_count: u64,
+    background_scan_compare_count: Option<u64>,
     #[serde(rename = "BackgroundScannedInMB")]
     background_scanned_in_mb: u64,
     bck_rebuild_read_bwc: BWC,
@@ -1831,7 +1831,7 @@ pub struct SystemStatistics {
     pub rebalance_per_receive_job_net_throttling_in_kbps: u64,
     pub fixed_read_error_count: u64,
     #[serde(rename = "BackgroundScanCompareCount")]
-    pub background_scan_compare_count: u64,
+    pub background_scan_compare_count: Option<u64>,
     #[serde(rename = "BackgroundScannedInMB")]
     pub background_scanned_in_mb: u64,
     pub primary_read_bwc: BWC,

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -1829,7 +1829,7 @@ pub struct SystemStatistics {
     pub rebalance_wait_send_q_length: u64,
     pub rebuild_per_receive_job_net_throttling_in_kbps: u64,
     pub rebalance_per_receive_job_net_throttling_in_kbps: u64,
-    pub fixed_read_error_count: u64,
+    pub fixed_read_error_count: Option<u64>, // Optional Statistic
     #[serde(rename = "BackgroundScanCompareCount")]
     pub background_scan_compare_count: Option<u64>,
     #[serde(rename = "BackgroundScannedInMB")]

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -1703,6 +1703,14 @@ fn test_system_response() {
 
     let i: Vec<System> = serde_json::from_str(&buff).unwrap();
     println!("result: {:#?}", i);
+
+    let mut f = File::open("tests/scaleio/system_v3.json").unwrap();
+    let mut buff = String::new();
+    f.read_to_string(&mut buff).unwrap();
+    println!("buff: {}", buff);
+
+    let i: Vec<System> = serde_json::from_str(&buff).unwrap();
+    println!("result: {:#?}", i);
 }
 
 #[derive(Debug, Deserialize, IntoPoint)]
@@ -1724,7 +1732,6 @@ pub struct System {
     pub tls_version: String,                            // in v3
     pub show_guid: bool,                                // in v3
     pub authentication_method: String,                  // in v3
-    pub mdm_to_sds_policy: Option<String>,                      // in v3
     pub mdm_cluster: MdmCluster,                        // in v3
     pub perf_profile: PerfProfile,                      // in v3
     pub install_id: String,                             // in v3

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -177,8 +177,8 @@ pub struct OscillatingCounterWindow {
     pub capacity_in_use_in_kb: Option<u64>,
     pub thick_capacity_in_use_in_kb: Option<u64>,
     pub thin_capacity_in_use_in_kb: Option<u64>,
-    pub snap_capacity_in_use_in_kb: Option<u64>,
-    pub snap_capacity_in_use_occupied_in_kb: Option<u64>,
+    pub snap_capacity_in_use_in_kb: Option<u64>, //deprecated in v3.5.1.4, will eventually return 0 and then be removed
+    pub snap_capacity_in_use_occupied_in_kb: Option<u64>, //deprecated in v3.5.1.4, will eventually return 0 and then be removed
     pub unreachable_unused_capacity_in_kb: Option<u64>,
     pub protected_vac_in_kb: Option<u64>,
     pub degraded_healthy_vac_in_kb: Option<u64>,
@@ -511,8 +511,8 @@ pub struct DeviceStatistics {
     secondary_read_from_rmcache_bwc: BWC,     // in v3
     secondary_write_bwc: BWC,                 // in v3
     semi_protected_vac_in_kb: u64,            // in v3
-    snap_capacity_in_use_occupied_in_kb: u64, // in v3
-    snap_capacity_in_use_in_kb: u64,          //in v3
+    snap_capacity_in_use_occupied_in_kb: Option<u64>, //deprecated in v3.5.1.4, will eventually return 0 and then be removed
+    snap_capacity_in_use_in_kb: Option<u64>,          //deprecated in v3.5.1.4, will eventually return 0 and then be removed
     snapshot_capacity_in_kb: Option<u64>,     // NEW V3
     temp_capacity_vac_in_kb: Option<u64>,     // NEW v3
     thick_capacity_in_use_in_kb: u64,         // in v3
@@ -1438,8 +1438,8 @@ pub struct SdsStatistics {
     secondary_vac_in_kb: u64,
     secondary_write_bwc: BWC,
     semi_protected_vac_in_kb: u64,
-    snap_capacity_in_use_in_kb: u64,
-    snap_capacity_in_use_occupied_in_kb: u64,
+    snap_capacity_in_use_in_kb: Option<u64>, //deprecated in v3.5.1.4, will eventually return 0 and then be removed
+    snap_capacity_in_use_occupied_in_kb: Option<u64>, //deprecated in v3.5.1.4, will eventually return 0 and then be removed
     thick_capacity_in_use_in_kb: u64,
     thin_capacity_allocated_in_km: u64,
     thin_capacity_in_use_in_kb: Option<u64>, // Deprecated, use net_thin_user_data_capacity_in_kb instead
@@ -1765,10 +1765,10 @@ pub struct SystemStatistics {
     pub thick_capacity_in_use_in_kb: u64,
     pub thin_capacity_in_use_in_kb: Option<u64>, //deprecated, use net_thin_user_data_capacity_in_kb * 2 instead
     pub net_thin_user_data_capacity_in_kb: Option<u64>,
-    pub snap_capacity_in_use_in_kb: u64,
+    pub snap_capacity_in_use_in_kb: Option<u64>, //deprecated in v3.5.1.4, will eventually return 0 and then be removed
     pub unreachable_unused_capacity_in_kb: u64,
     pub unused_capacity_in_kb: u64,
-    pub snap_capacity_in_use_occupied_in_kb: u64,
+    pub snap_capacity_in_use_occupied_in_kb: Option<u64>, //deprecated in v3.5.1.4, will eventually return 0 and then be removed
     pub thin_capacity_allocated_in_kb: u64,
     pub rm_pending_allocated_in_kb: u64,
     pub rm_pending_thick_in_kb: Option<u64>,

--- a/src/scaleio.rs
+++ b/src/scaleio.rs
@@ -2789,26 +2789,51 @@ impl Scaleio {
     }
 
     pub fn get_pool_stats(&self) -> MetricsResult<ClusterSelectedStatisticsResponse> {
-        let stats_req = SelectedStatisticsRequest {
-            selected_statistics_list: vec![StatsRequest {
-                req_type: StatsRequestType::StoragePool,
-                all_ids: vec![],
-                properties: vec![
-                    "numOfDevices".into(),
-                    "numOfVolumes".into(),
-                    "capacityLimitInKb".into(),
-                    "thickCapacityInUseInKb".into(),
-                    "netThinUserDataCapacityInKb".into(),// thinCapacityInUseInKb is deprecated"thinCapacityInUseInKb".into(),
-                    "primaryReadBwc".into(),
-                    "primaryWriteBwc".into(),
-                    "secondaryReadBwc".into(),
-                    "secondaryWriteBwc".into(),
-                    "totalReadBwc".into(),
-                    "totalWriteBwc".into(),
-                    "thinCapacityAllocatedInKm".into(),
-                ],
-            }],
-        };
+        let version = self.get_version();
+        if version >= 3.0 {
+            let stats_req = SelectedStatisticsRequest {
+                selected_statistics_list: vec![StatsRequest {
+                    req_type: StatsRequestType::StoragePool,
+                    all_ids: vec![],
+                    properties: vec![
+                        "numOfDevices".into(),
+                        "numOfVolumes".into(),
+                        "capacityLimitInKb".into(),
+                        "thickCapacityInUseInKb".into(),
+                        "netThinUserDataCapacityInKb".into(),// thinCapacityInUseInKb is deprecated"thinCapacityInUseInKb".into(),
+                        "primaryReadBwc".into(),
+                        "primaryWriteBwc".into(),
+                        "secondaryReadBwc".into(),
+                        "secondaryWriteBwc".into(),
+                        "totalReadBwc".into(),
+                        "totalWriteBwc".into(),
+                        "thinCapacityAllocatedInKm".into(),
+                    ],
+                }],
+            };
+        } else {
+            let stats_req = SelectedStatisticsRequest {
+                selected_statistics_list: vec![StatsRequest {
+                    req_type: StatsRequestType::StoragePool,
+                    all_ids: vec![],
+                    properties: vec![
+                        "numOfDevices".into(),
+                        "numOfVolumes".into(),
+                        "capacityLimitInKb".into(),
+                        "thickCapacityInUseInKb".into(),
+                        "thinCapacityInUseInKb".into(),
+                        "primaryReadBwc".into(),
+                        "primaryWriteBwc".into(),
+                        "secondaryReadBwc".into(),
+                        "secondaryWriteBwc".into(),
+                        "totalReadBwc".into(),
+                        "totalWriteBwc".into(),
+                        "thinCapacityAllocatedInKm".into(),
+                    ],
+                }],
+            };
+        }
+        
 
         // Contact scaleio metadata server and parse the results
         // back into json.  If the call isn't an http success result
@@ -2931,6 +2956,16 @@ impl Scaleio {
             points
         })?;
         Ok(systemstats)
+    }
+
+    /// Get the version number of the SIO API
+    pub fn get_version(&self) -> MetricsResult<f64> {
+        let version = get::<String>(
+            &self.client,
+            &self.config,
+            &format!("version"),
+        )?;
+        Ok(version.parse::<f64>()?);
     }
 
     pub fn get_system(&self, system_id: &str) -> MetricsResult<System> {

--- a/tests/scaleio/system_v3.json
+++ b/tests/scaleio/system_v3.json
@@ -1,0 +1,250 @@
+[
+    {
+        "restrictedSdcModeEnabled": false,
+        "restrictedSdcMode": "None",
+        "enterpriseFeaturesEnabled": true,
+        "isInitialLicense": false,
+        "swid": "E",
+        "daysInstalled": 19,
+        "maxCapacityInGb": "2457600",
+        "capacityTimeLeftInDays": "Unlimited",
+        "installId": "1",
+        "systemVersionName": "DellEMC PowerFlex Version: R3_5.1500.105",
+        "perfProfile": "HighPerformance",
+        "authenticationMethod": "NativeAndLdap",
+        "capacityAlertHighThresholdPercent": 80,
+        "capacityAlertCriticalThresholdPercent": 90,
+        "upgradeState": "NoUpgrade",
+        "remoteReadOnlyLimitState": false,
+        "mdmManagementPort": 6611,
+        "mdmExternalPort": 7611,
+        "sdcMdmNetworkDisconnectionsCounterParameters": {
+            "shortWindow": {
+                "windowSizeInSec": 60,
+                "threshold": 10000
+            },
+            "mediumWindow": {
+                "windowSizeInSec": 3600,
+                "threshold": 100000
+            },
+            "longWindow": {
+                "windowSizeInSec": 86400,
+                "threshold": 1000000
+            }
+        },
+        "sdcSdsNetworkDisconnectionsCounterParameters": {
+            "shortWindow": {
+                "windowSizeInSec": 60,
+                "threshold": 300
+            },
+            "mediumWindow": {
+                "windowSizeInSec": 3600,
+                "threshold": 500
+            },
+            "longWindow": {
+                "windowSizeInSec": 86400,
+                "threshold": 700
+            }
+        },
+        "sdcMemoryAllocationFailuresCounterParameters": {
+            "shortWindow": {
+                "windowSizeInSec": 60,
+                "threshold": 300
+            },
+            "mediumWindow": {
+                "windowSizeInSec": 3600,
+                "threshold": 500
+            },
+            "longWindow": {
+                "windowSizeInSec": 86400,
+                "threshold": 700
+            }
+        },
+        "sdcSocketAllocationFailuresCounterParameters": {
+            "shortWindow": {
+                "windowSizeInSec": 60,
+                "threshold": 300
+            },
+            "mediumWindow": {
+                "windowSizeInSec": 3600,
+                "threshold": 500
+            },
+            "longWindow": {
+                "windowSizeInSec": 86400,
+                "threshold": 700
+            }
+        },
+        "sdcLongOperationsCounterParameters": {
+            "shortWindow": {
+                "windowSizeInSec": 60,
+                "threshold": 10000
+            },
+            "mediumWindow": {
+                "windowSizeInSec": 3600,
+                "threshold": 100000
+            },
+            "longWindow": {
+                "windowSizeInSec": 86400,
+                "threshold": 1000000
+            }
+        },
+        "cliPasswordAllowed": true,
+        "managementClientSecureCommunicationEnabled": true,
+        "tlsVersion": "TLSv1.2",
+        "showGuid": true,
+        "defragmentationEnabled": true,
+        "mdmSecurityPolicy": "None",
+        "mdmCluster": {
+            "tieBreakers": [
+                {
+                    "opensslVersion": "N/A",
+                    "managementIPs": [
+                        "5.5.5.5"
+                    ],
+                    "ips": [
+                        "5.5.5.5"
+                    ],
+                    "versionInfo": "R3_5.1500.0",
+                    "role": "TieBreaker",
+                    "status": "Normal",
+                    "name": "server1",
+                    "id": "1234",
+                    "port": 9011
+                },
+                {
+                    "opensslVersion": "N/A",
+                    "managementIPs": [
+                        "5.5.5.5"
+                    ],
+                    "ips": [
+                        "5.5.5.5"
+                    ],
+                    "versionInfo": "R3_5.1500.0",
+                    "role": "TieBreaker",
+                    "status": "Normal",
+                    "name": "server2",
+                    "id": "123",
+                    "port": 9011
+                }
+            ],
+            "goodNodesNum": 5,
+            "goodReplicasNum": 3,
+            "master": {
+                "virtualInterfaces": [],
+                "opensslVersion": "OpenSSL 1.0.2k-fips  26 Jan 2017",
+                "managementIPs": [
+                    "5.5.5.5"
+                ],
+                "ips": [
+                    "5.5.5.5"
+                ],
+                "versionInfo": "R3_5.1500.0",
+                "role": "Manager",
+                "status": "Normal",
+                "name": "server3",
+                "id": "111",
+                "port": 9011
+            },
+            "slaves": [
+                {
+                    "virtualInterfaces": [],
+                    "opensslVersion": "OpenSSL 1.0.2k-fips  26 Jan 2017",
+                    "managementIPs": [
+                        "5.5.5.5"
+                    ],
+                    "ips": [
+                        "5.5.5.5"
+                    ],
+                    "versionInfo": "R3_5.1500.0",
+                    "role": "Manager",
+                    "status": "Normal",
+                    "name": "server4",
+                    "id": "11111111",
+                    "port": 9011
+                },
+                {
+                    "virtualInterfaces": [],
+                    "opensslVersion": "OpenSSL 1.0.2k-fips  26 Jan 2017",
+                    "managementIPs": [
+                        "5.5.5.5"
+                    ],
+                    "ips": [
+                        "5.5.5.5"
+                    ],
+                    "versionInfo": "R3_5.1500.0",
+                    "role": "Manager",
+                    "status": "Normal",
+                    "name": "server5",
+                    "id": "0000000000",
+                    "port": 9011
+                }
+            ],
+            "clusterState": "ClusteredNormal",
+            "clusterMode": "FiveNodes",
+            "name": "NAME",
+            "id": "123468798"
+        },
+        "sdcSdsConnectivityInfo": {
+            "clientServerConnectivityStatus": "AllConnected",
+            "disconnectedClientId": null,
+            "disconnectedClientName": null,
+            "disconnectedServerId": null,
+            "disconnectedServerName": null,
+            "disconnectedServerIp": null
+        },
+        "addressSpaceUsage": "Normal",
+        "lastUpgradeTime": 1652892642,
+        "sdcSdrConnectivityInfo": {
+            "clientServerConnectivityStatus": "AllConnected",
+            "disconnectedClientId": null,
+            "disconnectedClientName": null,
+            "disconnectedServerId": null,
+            "disconnectedServerName": null,
+            "disconnectedServerIp": null
+        },
+        "sdrSdsConnectivityInfo": {
+            "clientServerConnectivityStatus": "AllConnected",
+            "disconnectedClientId": null,
+            "disconnectedClientName": null,
+            "disconnectedServerId": null,
+            "disconnectedServerName": null,
+            "disconnectedServerIp": null
+        },
+        "name": "SIOHOBLK01",
+        "id": "12347234",
+        "links": [
+            {
+                "rel": "self",
+                "href": "/api/instances/System::123545"
+            },
+            {
+                "rel": "/api/System/relationship/Statistics",
+                "href": "/api/instances/System::123545/relationships/Statistics"
+            },
+            {
+                "rel": "/api/System/relationship/Sdr",
+                "href": "/api/instances/System::123545/relationships/Sdr"
+            },
+            {
+                "rel": "/api/System/relationship/ProtectionDomain",
+                "href": "/api/instances/System::123545/relationships/ProtectionDomain"
+            },
+            {
+                "rel": "/api/System/relationship/Sdc",
+                "href": "/api/instances/System::123545/relationships/Sdc"
+            },
+            {
+                "rel": "/api/System/relationship/User",
+                "href": "/api/instances/System::123545/relationships/User"
+            },
+            {
+                "rel": "/api/System/relationship/SnapshotPolicy",
+                "href": "/api/instances/System::123545/relationships/SnapshotPolicy"
+            },
+            {
+                "rel": "/api/System/relationship/PeerMdm",
+                "href": "/api/instances/System::123545/relationships/PeerMdm"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
The ScaleIO Powerflex update deprecated a few of the attributes.  This PR handles the deprecated attributes as well as adds in a workaround